### PR TITLE
Reset pushed array entry

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -61,7 +61,9 @@ export function handleMulticoinAddrChanged(event: AddressChangedEvent): void {
     resolver.coinTypes = [coinType];
     resolver.save();
   } else if(!resolver.coinTypes.includes(coinType)) {
-    resolver.coinTypes.push(coinType)
+    let coinTypes = resolver.coinTypes
+    coinTypes.push(coinType)
+    resolver.coinTypes = coinTypes
     resolver.save()
   }
 
@@ -104,11 +106,14 @@ export function handlePubkeyChanged(event: PubkeyChangedEvent): void {
 
 export function handleTextChanged(event: TextChangedEvent): void {
   let resolver = getOrCreateResolver(event.params.node, event.address)
+  let key = event.params.key;
   if(resolver.texts == null) {
-    resolver.texts = [event.params.key];
+    resolver.texts = [key];
     resolver.save();
-  } else if(!resolver.texts.includes(event.params.key)) {
-    resolver.texts.push(event.params.key)
+  } else if(!resolver.texts.includes(key)) {
+    let texts = resolver.texts
+    texts.push(key)
+    resolver.texts = texts
     resolver.save()
   }
 


### PR DESCRIPTION
From https://thegraph.com/docs/assemblyscript-api#api-reference

```
// This won't work
entity.numbers.push(BigInt.fromI32(1))
entity.save()

// This will work
let numbers = entity.numbers
numbers.push(BigInt.fromI32(1))
entity.numbers = numbers
entity.save()
```

**NOTE**

When I tested locally, the fix worked for coinTypes but not for texts because `handleTextChanged` was not emitting.

This could be because you have changed `TextChanged` by indexing one of the key, but abi is still old.

https://github.com/ensdomains/resolvers/commit/5a91dd090be78be8b35b80678656acc81fb54c6d

I could change it by updating ABI but it may cause another problem of emitting event handler before you made the change, so further investigation may be required.


