### PR TITLE
Fix index issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "setup": "npm run codegen && npm run create-local && npm run deploy-local",
     "codegen": "graph codegen --output-dir src/types/",
     "create-local": "graph create graphprotocol/ens --node http://127.0.0.1:8020",
+    "remove-local": "graph remove graphprotocol/ens --node http://127.0.0.1:8020",
     "build": "graph build",
     "deploy-local": "graph deploy graphprotocol/ens --debug --ipfs http://localhost:5001 --node http://127.0.0.1:8020/",
     "deploy": "graph deploy ensdomains/ens --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",

--- a/src/auctionRegistrar.ts
+++ b/src/auctionRegistrar.ts
@@ -26,6 +26,7 @@ import {
 
 // Import entity types generated from the GraphQL schema
 import { Account, AuctionedName, Deed } from './types/schema'
+import { byteArrayFromHex, concat } from './utils'
 
 var rootNode:ByteArray = byteArrayFromHex("93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae")
 
@@ -126,25 +127,3 @@ export function deedClosed(event: DeedClosed): void {
   }
 }
 
-// Helper for concatenating two byte arrays
-function concat(a: ByteArray, b: ByteArray): ByteArray {
-  let out = new Uint8Array(a.length + b.length)
-  for (let i = 0; i < a.length; i++) {
-    out[i] = a[i]
-  }
-  for (let j = 0; j < b.length; j++) {
-    out[a.length + j] = b[j]
-  }
-  return out as ByteArray
-}
-
-function byteArrayFromHex(s: string): ByteArray {
-  if(s.length % 2 !== 0) {
-    throw new TypeError("Hex string must have an even number of characters")
-  }
-  let out = new Uint8Array(s.length / 2)
-  for(var i = 0; i < s.length; i += 2) {
-    out[i / 2] = parseInt(s.substring(i, i + 2), 16) as u32
-  }
-  return out as ByteArray;
-}

--- a/src/ensRegistry.ts
+++ b/src/ensRegistry.ts
@@ -25,7 +25,7 @@ export function handleNewOwner(event: NewOwnerEvent): void {
   let account = new Account(event.params.owner.toHexString())
   account.save()
   let subnode = crypto.keccak256(concat(event.params.node, event.params.label)).toHexString()
-  let domain = newDomain(subnode)
+  let domain = new Domain(subnode)
   if(domain.name == null) {
     // Get label and node names
     let label = ens.nameByHash(event.params.label.toHexString())
@@ -62,9 +62,8 @@ export function handleTransfer(event: TransferEvent): void {
   let node = event.params.node.toHexString()
   let account = new Account(event.params.owner.toHexString())
   account.save()
-
   // Update the domain owner
-  let domain = newDomain(node)
+  let domain = new Domain(node)
   domain.owner = account.id
   domain.save()
 
@@ -81,7 +80,11 @@ export function handleNewResolver(event: NewResolverEvent): void {
   let id = event.params.resolver.toHexString().concat('-').concat(event.params.node.toHexString())
 
   let node = event.params.node.toHexString()
-  let domain = newDomain(node)
+  let domain = new Domain(node)
+  if(node == ROOT_NODE){
+    domain.owner = EMPTY_ADDRESS
+  }
+
   domain.resolver = id
 
   let resolver = Resolver.load(id)
@@ -107,7 +110,7 @@ export function handleNewResolver(event: NewResolverEvent): void {
 // Handler for NewTTL events
 export function handleNewTTL(event: NewTTLEvent): void {
   let node = event.params.node.toHexString()
-  let domain = newDomain(node)
+  let domain = new Domain(node)
   domain.ttl = event.params.ttl
   domain.save()
 
@@ -117,12 +120,4 @@ export function handleNewTTL(event: NewTTLEvent): void {
   domainEvent.domain = node
   domainEvent.ttl = event.params.ttl
   domainEvent.save()
-}
-
-export function newDomain(node:string): Domain {
-  let domain = new Domain(node)
-  if(node == ROOT_NODE){
-    domain.owner = EMPTY_ADDRESS
-  }
-  return domain as Domain
 }

--- a/src/ensRegistry.ts
+++ b/src/ensRegistry.ts
@@ -4,7 +4,6 @@ import {
   ens
 } from '@graphprotocol/graph-ts'
 
-import { log } from '@graphprotocol/graph-ts'
 import {
   createEventID, concat, ROOT_NODE, EMPTY_ADDRESS
 } from './utils'

--- a/src/ensRegistry.ts
+++ b/src/ensRegistry.ts
@@ -23,8 +23,10 @@ import { Account, Domain, Resolver, NewOwner, Transfer, NewResolver, NewTTL } fr
 export function handleNewOwner(event: NewOwnerEvent): void {
   let account = new Account(event.params.owner.toHexString())
   account.save()
+
   let subnode = crypto.keccak256(concat(event.params.node, event.params.label)).toHexString()
   let domain = new Domain(subnode)
+
   if(domain.name == null) {
     // Get label and node names
     let label = ens.nameByHash(event.params.label.toHexString())
@@ -59,8 +61,10 @@ export function handleNewOwner(event: NewOwnerEvent): void {
 // Handler for Transfer events
 export function handleTransfer(event: TransferEvent): void {
   let node = event.params.node.toHexString()
+
   let account = new Account(event.params.owner.toHexString())
   account.save()
+
   // Update the domain owner
   let domain = new Domain(node)
   domain.owner = account.id

--- a/src/ensRegistry.ts
+++ b/src/ensRegistry.ts
@@ -6,7 +6,7 @@ import {
 
 import { log } from '@graphprotocol/graph-ts'
 import {
-  createEventID, loadOrCreateDomain, concat
+  createEventID, concat, ROOT_NODE, EMPTY_ADDRESS
 } from './utils'
 
 // Import event types from the registry contract ABI
@@ -25,7 +25,7 @@ export function handleNewOwner(event: NewOwnerEvent): void {
   let account = new Account(event.params.owner.toHexString())
   account.save()
   let subnode = crypto.keccak256(concat(event.params.node, event.params.label)).toHexString()
-  let domain = loadOrCreateDomain(subnode)
+  let domain = newDomain(subnode)
   if(domain.name == null) {
     // Get label and node names
     let label = ens.nameByHash(event.params.label.toHexString())
@@ -64,7 +64,7 @@ export function handleTransfer(event: TransferEvent): void {
   account.save()
 
   // Update the domain owner
-  let domain = loadOrCreateDomain(node)
+  let domain = newDomain(node)
   domain.owner = account.id
   domain.save()
 
@@ -81,7 +81,7 @@ export function handleNewResolver(event: NewResolverEvent): void {
   let id = event.params.resolver.toHexString().concat('-').concat(event.params.node.toHexString())
 
   let node = event.params.node.toHexString()
-  let domain = loadOrCreateDomain(node)
+  let domain = newDomain(node)
   domain.resolver = id
 
   let resolver = Resolver.load(id)
@@ -107,7 +107,7 @@ export function handleNewResolver(event: NewResolverEvent): void {
 // Handler for NewTTL events
 export function handleNewTTL(event: NewTTLEvent): void {
   let node = event.params.node.toHexString()
-  let domain = loadOrCreateDomain(node)
+  let domain = newDomain(node)
   domain.ttl = event.params.ttl
   domain.save()
 
@@ -117,4 +117,12 @@ export function handleNewTTL(event: NewTTLEvent): void {
   domainEvent.domain = node
   domainEvent.ttl = event.params.ttl
   domainEvent.save()
+}
+
+export function newDomain(node:string): Domain {
+  let domain = new Domain(node)
+  if(node == ROOT_NODE){
+    domain.owner = EMPTY_ADDRESS
+  }
+  return domain as Domain
 }

--- a/src/ethRegistrar.ts
+++ b/src/ethRegistrar.ts
@@ -94,19 +94,16 @@ export function handleNameRenewed(event: NameRenewedEvent): void {
 export function handleNameTransferred(event: TransferEvent): void {
   let label = uint256ToByteArray(event.params.tokenId)
   let transferEvent = new NameTransferred(createEventID(event))
+  let registrant = event.params.to.toHex()
+  let registration = Registration.load(label.toHex())
+  if(registration != null){
+    registration.registrant = registrant
+    registration.save()
+  }
+
   transferEvent.registration = label.toHex()
   transferEvent.blockNumber = event.block.number.toI32()
   transferEvent.transactionID = event.transaction.hash
-  // This registration is loaded to refer to registration.registrant.
-  let registration = Registration.load(label.toHex())
-  // This is when minting new name, called by _mint()
-  // Saving the object at this stage will throw an error 
-  // because other mandatory fields (eg: registrationDate) are not set
-  // when minting as ERC721 token
-  if(registration == null){
-    transferEvent.newOwner = event.params.to.toHex()    
-  }else{
-    transferEvent.newOwner = registration.registrant
-  }
+  transferEvent.newOwner = registrant
   transferEvent.save()
 }

--- a/src/ethRegistrar.ts
+++ b/src/ethRegistrar.ts
@@ -93,13 +93,16 @@ export function handleNameRenewed(event: NameRenewedEvent): void {
 
 export function handleNameTransferred(event: TransferEvent): void {
   let label = uint256ToByteArray(event.params.tokenId)
-  // Do not create new registration
-  let registration = Registration.load(label.toHex())
   let transferEvent = new NameTransferred(createEventID(event))
   transferEvent.registration = label.toHex()
   transferEvent.blockNumber = event.block.number.toI32()
   transferEvent.transactionID = event.transaction.hash
+  // This registration is loaded to refer to registration.registrant.
+  let registration = Registration.load(label.toHex())
   // This is when minting new name, called by _mint()
+  // Saving the object at this stage will throw an error 
+  // because other mandatory fields (eg: registrationDate) are not set
+  // when minting as ERC721 token
   if(registration == null){
     transferEvent.newOwner = event.params.to.toHex()    
   }else{

--- a/src/ethRegistrar.ts
+++ b/src/ethRegistrar.ts
@@ -93,14 +93,14 @@ export function handleNameRenewed(event: NameRenewedEvent): void {
 
 export function handleNameTransferred(event: TransferEvent): void {
   let label = uint256ToByteArray(event.params.tokenId)
-  let transferEvent = new NameTransferred(createEventID(event))
   let registrant = event.params.to.toHex()
   let registration = Registration.load(label.toHex())
-  if(registration != null){
-    registration.registrant = registrant
-    registration.save()
-  }
+  if(registration != null) return;
 
+  registration.registrant = registrant
+  registration.save()
+
+  let transferEvent = new NameTransferred(createEventID(event))
   transferEvent.registration = label.toHex()
   transferEvent.blockNumber = event.block.number.toI32()
   transferEvent.transactionID = event.transaction.hash

--- a/src/ethRegistrar.ts
+++ b/src/ethRegistrar.ts
@@ -95,7 +95,7 @@ export function handleNameTransferred(event: TransferEvent): void {
   let label = uint256ToByteArray(event.params.tokenId)
   let registrant = event.params.to.toHex()
   let registration = Registration.load(label.toHex())
-  if(registration != null) return;
+  if(registration == null) return;
 
   registration.registrant = registrant
   registration.save()

--- a/src/ethRegistrar.ts
+++ b/src/ethRegistrar.ts
@@ -69,7 +69,7 @@ export function handleNameRegistered(event: NameRegisteredEvent): void {
 }
 
 export function handleNameRegisteredByController(event: ControllerNameRegisteredEvent): void {
-  let domain = newDomain(crypto.keccak256(concat(rootNode, event.params.label)).toHex())
+  let domain = new Domain(crypto.keccak256(concat(rootNode, event.params.label)).toHex())
   if(domain.labelName !== event.params.name) {
     domain.labelName = event.params.name
     domain.name = event.params.name + '.eth'
@@ -106,12 +106,4 @@ export function handleNameTransferred(event: TransferEvent): void {
     transferEvent.newOwner = registration.registrant
   }
   transferEvent.save()
-}
-
-export function newDomain(node:string): Domain {
-  let domain = new Domain(node)
-  if(node == ROOT_NODE){
-    domain.owner = EMPTY_ADDRESS
-  }
-  return domain as Domain
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,8 +4,6 @@ import {
   ByteArray,
   EthereumEvent,
 } from '@graphprotocol/graph-ts'
-// Import entity types generated from the GraphQL schema
-import { Domain, Registration } from './types/schema'
 
 export function createEventID(event: EthereumEvent): string {
   return event.block.number.toString().concat('-').concat(event.logIndex.toString())

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,63 @@
+// Import types and APIs from graph-ts
+import {
+  BigInt,
+  ByteArray,
+  EthereumEvent,
+} from '@graphprotocol/graph-ts'
+// Import entity types generated from the GraphQL schema
+import { Domain, Registration } from './types/schema'
+
+export function createEventID(event: EthereumEvent): string {
+  return event.block.number.toString().concat('-').concat(event.logIndex.toString())
+}
+
+export const ROOT_NODE = '0x0000000000000000000000000000000000000000000000000000000000000000'
+export const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+export function loadOrCreateDomain(node:string): Domain {
+  let domain = Domain.load(node)
+  if (domain == null){
+    domain = new Domain(node)
+    if(node == ROOT_NODE){
+      domain.owner = EMPTY_ADDRESS
+    }
+  }
+  return domain as Domain
+}
+
+export function loadOrCreateRegistration(label:string): Registration {
+  let registration = Registration.load(label)
+  
+  if (registration == null){
+    registration = new Registration(label)
+  }
+  return registration as Registration
+}
+
+// Helper for concatenating two byte arrays
+export function concat(a: ByteArray, b: ByteArray): ByteArray {
+  let out = new Uint8Array(a.length + b.length)
+  for (let i = 0; i < a.length; i++) {
+    out[i] = a[i]
+  }
+  for (let j = 0; j < b.length; j++) {
+    out[a.length + j] = b[j]
+  }
+  return out as ByteArray
+}
+
+export function byteArrayFromHex(s: string): ByteArray {
+  if(s.length % 2 !== 0) {
+    throw new TypeError("Hex string must have an even number of characters")
+  }
+  let out = new Uint8Array(s.length / 2)
+  for(var i = 0; i < s.length; i += 2) {
+    out[i / 2] = parseInt(s.substring(i, i + 2), 16) as u32
+  }
+  return out as ByteArray;
+}
+
+export function uint256ToByteArray(i: BigInt): ByteArray {
+  let hex = i.toHex().slice(2).padStart(64, '0')
+  return byteArrayFromHex(hex)
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,26 +14,6 @@ export function createEventID(event: EthereumEvent): string {
 export const ROOT_NODE = '0x0000000000000000000000000000000000000000000000000000000000000000'
 export const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000'
 
-export function loadOrCreateDomain(node:string): Domain {
-  let domain = Domain.load(node)
-  if (domain == null){
-    domain = new Domain(node)
-    if(node == ROOT_NODE){
-      domain.owner = EMPTY_ADDRESS
-    }
-  }
-  return domain as Domain
-}
-
-export function loadOrCreateRegistration(label:string): Registration {
-  let registration = Registration.load(label)
-  
-  if (registration == null){
-    registration = new Registration(label)
-  }
-  return registration as Registration
-}
-
 // Helper for concatenating two byte arrays
 export function concat(a: ByteArray, b: ByteArray): ByteArray {
   let out = new Uint8Array(a.length + b.length)


### PR DESCRIPTION


## Domain does not have a owner

### Symptom

```
ERRO Subgraph instance failed to run: Failed to process trigger in transaction 0x0e58…4356: Failed to handle Ethereum event with handler "handleNewResolver": Entity Domain[0x0000000000000000000000000000000000000000000000000000000000000000]: missing value for non-nullable field `owner`
```

### Reason

From https://github.com/ensdomains/ens-subgraph-ghsa-m9g2-g2hw-pq94/pull/1#discussion_r359112066

```
It looks like your test script sets a resolver on 0, which isn't something we previously expected to happen. That node doesn't have an entry in the subgraph by default. One way to fix this would be to create a special entry just for 0 when we first encounter it.
```

### Fix

```
    if(node == ROOT_NODE){
      domain.owner = EMPTY_ADDRESS
    }
```


## Registration does not have `registrationDate`

### Reason

The previous assumption was that `baseRegistrar.register` emits `NameRegistered` event which sets `registrationDate` with `block.timestamp`. However, registrar triggers `_mint` event which triggers `handleNameTransferred` where it was failing to save `registration` schema.

Here is the event dispatch sequence of `controller.register()`

```
    controller.register()
        base.register()
            _mint(owner, id)
                emit Transfer(address(0), to, tokenId);
                
            ens.setSubnodeOwner(baseNode, bytes32(id), owner);
                emit registry.NewOwner(node, label, owner);
        emit base.NameRegistered(id, owner, now + duration);
    emit controller.NameRegistered
```

### Fix

At `handleNameTransferred`, do not save `registration` so that schema validation does not happen.

## Other refactorings

- Move utility functions to `utils.ts`
- Create loadOrCreateDomain
- Create loadOrCreateRegistration