### PR TITLE
Add createdAt

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -10,7 +10,7 @@ type Domain @entity {
   resolver: Resolver
   ttl: BigInt
   isMigrated: Boolean!
-  createdAt: BigInt
+  createdAt: BigInt!
   events: [DomainEvent!]! @derivedFrom(field: "domain")
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -10,6 +10,7 @@ type Domain @entity {
   resolver: Resolver
   ttl: BigInt
   isMigrated: Boolean!
+  createdAt: BigInt
   events: [DomainEvent!]! @derivedFrom(field: "domain")
 }
 

--- a/src/ensRegistry.ts
+++ b/src/ensRegistry.ts
@@ -1,5 +1,6 @@
 // Import types and APIs from graph-ts
 import {
+  BigInt,
   crypto,
   ens
 } from '@graphprotocol/graph-ts'
@@ -19,20 +20,24 @@ import {
 // Import entity types generated from the GraphQL schema
 import { Account, Domain, Resolver, NewOwner, Transfer, NewResolver, NewTTL } from './types/schema'
 
-function createDomain(node: string): Domain {
+const BIG_INT_ZERO = BigInt.fromI32(0)
+
+function createDomain(node: string, timestamp: BigInt): Domain {
   let domain = new Domain(node)
   if(node == ROOT_NODE) {
     domain = new Domain(node)
     domain.owner = EMPTY_ADDRESS
     domain.isMigrated = true
+    domain.createdAt = timestamp
+    domain.save()
   }
   return domain
 }
 
-function getDomain(node: string): Domain|null {
+function getDomain(node: string, timestamp: BigInt = BIG_INT_ZERO): Domain|null {
   let domain = Domain.load(node)
   if(domain == null && node == ROOT_NODE) {
-    return createDomain(node)
+    return createDomain(node, timestamp)
   }
   return domain
 }
@@ -43,7 +48,7 @@ function _handleNewOwner(event: NewOwnerEvent, isMigrated: boolean): void {
   account.save()
 
   let subnode = crypto.keccak256(concat(event.params.node, event.params.label)).toHexString()
-  let domain = getDomain(subnode);
+  let domain = getDomain(subnode, event.block.timestamp);
   if(domain == null) {
     domain = new Domain(subnode)
     domain.createdAt = event.block.timestamp
@@ -90,7 +95,7 @@ export function handleTransfer(event: TransferEvent): void {
   account.save()
 
   // Update the domain owner
-  let domain = createDomain(node);
+  let domain = getDomain(node)
   domain.owner = account.id
   domain.save()
 
@@ -107,7 +112,7 @@ export function handleNewResolver(event: NewResolverEvent): void {
   let id = event.params.resolver.toHexString().concat('-').concat(event.params.node.toHexString())
 
   let node = event.params.node.toHexString()
-  let domain = createDomain(node)
+  let domain = getDomain(node)
   domain.resolver = id
 
   let resolver = Resolver.load(id)
@@ -133,7 +138,7 @@ export function handleNewResolver(event: NewResolverEvent): void {
 // Handler for NewTTL events
 export function handleNewTTL(event: NewTTLEvent): void {
   let node = event.params.node.toHexString()
-  let domain = createDomain(node)
+  let domain = getDomain(node)
   domain.ttl = event.params.ttl
   domain.save()
 
@@ -160,8 +165,7 @@ export function handleNewOwnerOldRegistry(event: NewOwnerEvent): void {
 
 export function handleNewResolverOldRegistry(event: NewResolverEvent): void {
   let node = event.params.node.toHexString()
-  let domain = getDomain(node)
-
+  let domain = getDomain(node, event.block.timestamp)
   if(node == ROOT_NODE || !domain.isMigrated){
     handleNewResolver(event)
   }

--- a/src/ensRegistry.ts
+++ b/src/ensRegistry.ts
@@ -46,6 +46,7 @@ function _handleNewOwner(event: NewOwnerEvent, isMigrated: boolean): void {
   let domain = getDomain(subnode);
   if(domain == null) {
     domain = new Domain(subnode)
+    domain.createdAt = event.block.timestamp
   }
 
   if(domain.name == null) {


### PR DESCRIPTION

This allows us to find out how many new subdomains and non .eth domains are registered by doing something like this where `parent_in` is the list of tld ids.

```
query getDomainsByCreatedAt($timestamp: Int!){
	domains(where:{
    parent_not_in:["0x0000000000000000000000000000000000000000000000000000000000000000", "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6","0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae","0xa097f6721ce401e757d1223a763fef49b8b5f90bb18567ddb86fd205dff71d34"],
    createdAt_gt:$timestamp
  }){
    id
    name
    createdAt
    parent{
      id
      name
    }
  }
}
```

NOTE: I couldn't do `createdAt: BigIn!` due to the following error.


```
graph-node_1  | Dec 21 12:30:06.692 INFO Done processing Ethereum trigger, waiting_ms: 0, handler: handleNewResolverOldRegistry, total_ms: 5, trigger_type: Log, address: 0x1246…8c5f, signature: NewResolver(indexed bytes32,address), block_hash: 0x000834914a1655771e7eb6a4cecfe32c8a9bfbb07b2ef3fa4fb6f8ca4bfed88c, block_number: 9, subgraph_id: QmX9nMzfCh98d14E9FuehPK2ngULufufcRvJ7Cajn347K9, component: SubgraphInstanceManager
graph-node_1  | Dec 21 12:30:06.697 ERRO Subgraph instance failed to run: Failed to process trigger in block #9 (000834914a1655771e7eb6a4cecfe32c8a9bfbb07b2ef3fa4fb6f8ca4bfed88c), transaction c7d6faffddb7f485fb15871b2e906217dee80e985309a2873728b8396182523e: Failed to handle Ethereum event with handler "handleNewResolverOldRegistry": Entity Domain[0x0000000000000000000000000000000000000000000000000000000000000000]: missing value for non-nullable field `createdAt`, code: SubgraphSyncingFailure, id: QmX9nMzfCh98d14E9FuehPK2ngULufufcRvJ7Cajn347K9, subgraph_id: QmX9nMzfCh98d14E9FuehPK2ngULufufcRvJ7Cajn347K9, component: SubgraphInstanceManager

```

I am guessing that the root domain is created in different ways but couldn't figure out where. Any suggestion which allows me to make createdAt mandatory field welcome.