### PR TITLE
Support Cointype

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -111,7 +111,7 @@ type Resolver @entity {
   addr: Account             # Current value of addr record (per events)
   contentHash: Bytes        # Content hash, in binary format.
   texts: [String!]          # Set of observed text record keys
-  coinTypes: [Int!]         # Set of observed SLIP-44 coin types
+  coinTypes: [BigInt!]      # Set of observed SLIP-44 coin types
   events: [ResolverEvent!]! @derivedFrom(field: "resolver")
 }
 
@@ -135,7 +135,7 @@ type MulticoinAddrChanged implements ResolverEvent @entity {
   resolver: Resolver!
   blockNumber: Int!
   transactionID: Bytes!
-  coinType: Int!
+  coinType: BigInt!
   addr: Bytes!
 }
 

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -56,12 +56,7 @@ export function handleAddrChanged(event: AddrChangedEvent): void {
 export function handleMulticoinAddrChanged(event: AddressChangedEvent): void {
   let resolver = getOrCreateResolver(event.params.node, event.address)
 
-  // Handle cointypes that are outside the range we support
-  if(!event.params.coinType.isI32()) {
-    return;
-  }
-
-  let coinType = event.params.coinType.toI32()
+  let coinType = event.params.coinType
   if(resolver.coinTypes == null) {
     resolver.coinTypes = [coinType];
     resolver.save();


### PR DESCRIPTION

Dependent on https://github.com/ensdomains/address-encoder/pull/322
This PR changes coinType data type from Int to BigInt so that it can support EVM chainId coinTypes that are newly introduced