### PR TITLE
Change from new Registration to Registration.load

### DIFF
--- a/src/ethRegistrar.ts
+++ b/src/ethRegistrar.ts
@@ -85,7 +85,7 @@ export function handleNameRenewedByController(event: ControllerNameRenewedEvent)
 
 export function handleNameRenewed(event: NameRenewedEvent): void {
   let label = uint256ToByteArray(event.params.id)
-  let registration = new Registration(label.toHex())
+  let registration = Registration.load(label.toHex())!
   registration.expiryDate = event.params.expires
   registration.save()
 


### PR DESCRIPTION
Currently the following query returns "Null value resolved for non-null field `registrant`"

```
{
    registrations(where:{registrant:""}) {
      id
      domain {
        name
      }
      registrant {
        id
      }
    }
}
```

If this PR fixes the problem, then it should simply return an empty array. Currently testing at https://thegraph.com/hosted-service/subgraph/makoto/ensgoerli2?version=pending

