### PR TITLE
Update Readme.md to correct quick-start link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ENS Subgraph
 
-This Subgraph sources events from the ENS contracts. This includes the ENS registry, the Auction Registrar, and any resolvers that are created and linked to domains. The resolvers are added through dynamic data sources. More information on all of this can be found at [The Graph Documentation](https://thegraph.com/docs/quick-start).
+This Subgraph sources events from the ENS contracts. This includes the ENS registry, the Auction Registrar, and any resolvers that are created and linked to domains. The resolvers are added through dynamic data sources. More information on all of this can be found at [The Graph Documentation](https://thegraph.com/docs/developer/quick-start/).
 
 # Example Queries
 


### PR DESCRIPTION
Updated https://thegraph.com/docs/quick-start/ which was returning a 404 error to https://thegraph.com/docs/developer/quick-start/