### PR TITLE
Revert TextChanged value addition

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -171,7 +171,6 @@ type TextChanged implements ResolverEvent @entity {
   blockNumber: Int!
   transactionID: Bytes!
   key: String!
-  value: String
 }
 
 type ContenthashChanged implements ResolverEvent @entity {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -99,8 +99,6 @@ export function handlePubkeyChanged(event: PubkeyChangedEvent): void {
 
 export function handleTextChanged(event: TextChangedEvent): void {
   let resolver = getOrCreateResolver(event.params.node, event.address)
-  let contract = ResolverContract.bind(event.address)
-  let value = contract.try_text(event.params.node, event.params.key)
 
   let key = event.params.key;
   if(resolver.texts == null) {
@@ -120,7 +118,6 @@ export function handleTextChanged(event: TextChangedEvent): void {
   resolverEvent.blockNumber = event.block.number.toI32()
   resolverEvent.transactionID = event.transaction.hash
   resolverEvent.key = event.params.key
-  resolverEvent.value = value.value
   resolverEvent.save()
 }
 


### PR DESCRIPTION
querying the text record value from the resolver at every TextChanged event is currently causing the subgraph to often go out of sync for long periods of time (24 hours+).

this was originally added as a nice to have but with this much slowdown should be removed (can be implemented in the upcoming public resolver as an emitted value)