### PR TITLE
Add ReverseClaimed

### DIFF
--- a/abis/ReverseRegistrar.json
+++ b/abis/ReverseRegistrar.json
@@ -1,0 +1,323 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract ENS",
+        "name": "ensAddr",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "controller",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "ControllerChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "node",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ReverseClaimed",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "claim",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "resolver",
+        "type": "address"
+      }
+    ],
+    "name": "claimForAddr",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "resolver",
+        "type": "address"
+      }
+    ],
+    "name": "claimWithResolver",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "controllers",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "defaultResolver",
+    "outputs": [
+      {
+        "internalType": "contract NameResolver",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ens",
+    "outputs": [
+      {
+        "internalType": "contract ENS",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "node",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "controller",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "setController",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "resolver",
+        "type": "address"
+      }
+    ],
+    "name": "setDefaultResolver",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      }
+    ],
+    "name": "setName",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "resolver",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      }
+    ],
+    "name": "setNameForAddr",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/schema.graphql
+++ b/schema.graphql
@@ -160,7 +160,7 @@ type Resolver @entity {
   contentHash: Bytes # Content hash, in binary format.
   texts: [String!] # Set of observed text record keys
   coinTypes: [BigInt!] # Set of observed SLIP-44 coin types
-  primaryName: String
+  name: String
   events: [ResolverEvent!]! @derivedFrom(field: "resolver")
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,12 +1,12 @@
 type Domain @entity {
-  id: ID!                                               # The namehash of the name
-  name: String                                          # The human readable name, if known. Unknown portions replaced with hash in square brackets (eg, foo.[1234].eth)
-  labelName: String                                     # The human readable label name (imported from CSV), if known
-  labelhash: Bytes                                      # keccak256(labelName)
-  parent: Domain                                        # The namehash (id) of the parent name
-  subdomains: [Domain!]! @derivedFrom(field: "parent")  # Can count domains from length of array
-  subdomainCount: Int!                                  # The number of subdomains
-  resolvedAddress: Account                              # Address logged from current resolver, if any
+  id: ID! # The namehash of the name
+  name: String # The human readable name, if known. Unknown portions replaced with hash in square brackets (eg, foo.[1234].eth)
+  labelName: String # The human readable label name (imported from CSV), if known
+  labelhash: Bytes # keccak256(labelName)
+  parent: Domain # The namehash (id) of the parent name
+  subdomains: [Domain!]! @derivedFrom(field: "parent") # Can count domains from length of array
+  subdomainCount: Int! # The number of subdomains
+  resolvedAddress: Account # Address logged from current resolver, if any
   owner: Account!
   resolver: Resolver
   ttl: BigInt
@@ -90,7 +90,7 @@ type FusesSet implements DomainEvent @entity {
   domain: Domain!
   blockNumber: Int!
   transactionID: Bytes!
-  fuses: BigInt! 
+  fuses: BigInt!
   expiry: BigInt!
 }
 
@@ -147,25 +147,26 @@ type WrappedDomain @entity {
 type Account @entity {
   id: ID!
   domains: [Domain!]! @derivedFrom(field: "owner")
+  reverseDomain: Domain
   wrappedDomains: [WrappedDomain!] @derivedFrom(field: "owner")
   registrations: [Registration!] @derivedFrom(field: "registrant")
 }
 
 type Resolver @entity {
-  id: ID!                   # Concatenation of resolver address and namehash
+  id: ID! # Concatenation of resolver address and namehash
   domain: Domain
-  address: Bytes!           # Address of resolver contract
-
-  addr: Account             # Current value of addr record (per events)
-  contentHash: Bytes        # Content hash, in binary format.
-  texts: [String!]          # Set of observed text record keys
-  coinTypes: [BigInt!]      # Set of observed SLIP-44 coin types
+  address: Bytes! # Address of resolver contract
+  addr: Account # Current value of addr record (per events)
+  contentHash: Bytes # Content hash, in binary format.
+  texts: [String!] # Set of observed text record keys
+  coinTypes: [BigInt!] # Set of observed SLIP-44 coin types
+  primaryName: String
   events: [ResolverEvent!]! @derivedFrom(field: "resolver")
 }
 
 interface ResolverEvent {
-  id: ID!                   # Concatenation of block number and log ID
-  resolver: Resolver!       # Used to derive relationships to Resolvers
+  id: ID! # Concatenation of block number and log ID
+  resolver: Resolver! # Used to derive relationships to Resolvers
   blockNumber: Int!
   transactionID: Bytes!
 }
@@ -246,4 +247,12 @@ type AuthorisationChanged implements ResolverEvent @entity {
   owner: Bytes!
   target: Bytes!
   isAuthorized: Boolean!
+}
+
+type ReverseClaimed @entity {
+  id: ID!
+  registrant: Account!
+  domain: Domain!
+  blockNumber: Int!
+  transactionID: Bytes!
 }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -71,7 +71,7 @@ export function handleNameChanged(event: NameChangedEvent): void {
   if(event.params.name.indexOf("\u0000") != -1) return;
   
   let resolver = getOrCreateResolver(event.params.node, event.address)
-  resolver.primaryName = event.params.name
+  resolver.name = event.params.name
   resolver.save()
 
   let resolverEvent = new NameChanged(createEventID(event))

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -70,6 +70,10 @@ export function handleMulticoinAddrChanged(event: AddressChangedEvent): void {
 export function handleNameChanged(event: NameChangedEvent): void {
   if(event.params.name.indexOf("\u0000") != -1) return;
   
+  let resolver = getOrCreateResolver(event.params.node, event.address)
+  resolver.primaryName = event.params.name
+  resolver.save()
+
   let resolverEvent = new NameChanged(createEventID(event))
   resolverEvent.resolver = createResolverID(event.params.node, event.address)
   resolverEvent.blockNumber = event.block.number.toI32()

--- a/src/reverseRegistrar.ts
+++ b/src/reverseRegistrar.ts
@@ -1,0 +1,18 @@
+import { ReverseClaimed } from "./types/ReverseRegistrar/ReverseRegistrar";
+import { Account, Domain, ReverseClaimed as ReverseClaimedEvent } from "./types/schema";
+import { createEventID } from './utils'
+
+export function handleReverseClaimed(event: ReverseClaimed): void {
+    const account = new Account(event.params.addr.toHex())
+    const domain = new Domain(event.params.node.toHex())
+    domain.save()
+    account.reverseDomain = domain.id
+    account.save()
+
+    let reverseClaimedEvent = new ReverseClaimedEvent(createEventID(event))
+    reverseClaimedEvent.registrant = account.id
+    reverseClaimedEvent.domain = domain.id
+    reverseClaimedEvent.blockNumber = event.block.number.toI32()
+    reverseClaimedEvent.transactionID = event.transaction.hash
+    reverseClaimedEvent.save()
+}

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -199,3 +199,21 @@ dataSources:
           handler: handleNameUnwrapped
         - event: "FusesSet(indexed bytes32,uint32,uint64)"
           handler: handleFusesSet
+  - kind: ethereum/contract
+    name: ReverseRegistrar
+    network: mainnet
+    source:
+      abi: ReverseRegistrar
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/reverseRegistrar.ts
+      entities:
+        - ReverseRegistration
+      abis:
+        - name: ReverseRegistrar
+          file: ./abis/ReverseRegistrar.json
+      eventHandlers:
+        - event: "ReverseClaimed(indexed address,indexed bytes32)"
+          handler: handleReverseClaimed


### PR DESCRIPTION
Addresses https://github.com/ensdomains/ens-subgraph/issues/37

- Add `ReverseClaimed` event
- Add `resolver.primaryName`
- Add `account.reverseDomain` 

Tested against ens-app-v3 test data 

<img width="1478" alt="Screenshot 2022-09-12 at 17 49 46" src="https://user-images.githubusercontent.com/2630/189711465-7e7ff18f-6959-4074-94e9-966cd2d0505c.png">

NOTE:
- `ReverseClaimed` event currently does not exist. It's due to be added at the next release (the address is not added into the subgraph.yml yet)
- `NameChanged` event is only emitted by [PublicResolver.sol](https://github.com/ensdomains/ens-contracts/blob/master/contracts/resolvers/PublicResolver.sol). Some of the earlier names are managed by [DefaultReverseResolver.sol](https://github.com/ensdomains/ens-archived-contracts/blob/main/contracts/resolver/DefaultReverseResolver.sol) which does not emit the event
