### PR TITLE
fix: namewrapper transfer events

### DIFF
--- a/src/nameWrapper.ts
+++ b/src/nameWrapper.ts
@@ -108,7 +108,12 @@ export function handleFusesSet(event: FusesSetEvent): void {
 
 function makeWrappedTransfer(blockNumber: i32, transactionID: Bytes, eventID: string, node: string, to: string): void {
   const _to = createOrLoadAccount(to)
-  const wrappedDomain = WrappedDomain.load(node)!
+  let wrappedDomain = WrappedDomain.load(node)
+  // new registrations emit the Transfer` event before the NameWrapped event
+  // so we need to create the WrappedDomain entity here
+  if (wrappedDomain == null) {
+    wrappedDomain = new WrappedDomain(node)
+  }
   wrappedDomain.owner = _to.id
   wrappedDomain.save()
   const wrappedTransfer = new WrappedTransfer(eventID)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import {
   ByteArray,
   ethereum
 } from '@graphprotocol/graph-ts'
-import { Account } from './types/schema'
+import { Account, Domain } from './types/schema'
 
 export function createEventID(event:  ethereum.Event): string {
   return event.block.number.toString().concat('-').concat(event.logIndex.toString())
@@ -50,4 +50,14 @@ export function createOrLoadAccount(address: string): Account {
   }
 
   return account
+}
+
+export function createOrLoadDomain(node: string): Domain {
+  let domain = Domain.load(node)
+  if (domain == null) {
+    domain = new Domain(node)
+    domain.save()
+  }
+
+  return domain
 }

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -205,3 +205,7 @@ dataSources:
           handler: handleNameUnwrapped
         - event: "FusesSet(indexed bytes32,uint32,uint64)"
           handler: handleFusesSet
+        - event: TransferSingle(indexed address,indexed address,indexed address,uint256,uint256)
+          handler: handleTransferSingle
+        - event: TransferBatch(indexed address,indexed address,indexed address,uint256[],uint256[])
+          handler: handleTransferBatch


### PR DESCRIPTION
previously NameWrapper transfers were not tracked, this PR adds tracking for the TransferSingle and TransferBatch events so that ownership of a wrapped name is correct