### PR TITLE
fix: FusesSet expiry

### DIFF
--- a/src/nameWrapper.ts
+++ b/src/nameWrapper.ts
@@ -100,13 +100,13 @@ export function handleFusesSet(event: FusesSetEvent): void {
   wrappedDomain.fuses = fuses
   wrappedDomain.expiryDate = expiry
   wrappedDomain.save()
-  let fusesBurnedEvent = new FusesSet(createEventID(event))  
-  fusesBurnedEvent.domain = node.toHex()
-  fusesBurnedEvent.fuses = fuses
-  fusesBurnedEvent.blockNumber = blockNumber
-  fusesBurnedEvent.transactionID = transactionID
-  fusesBurnedEvent.expiry = expiry
-  fusesBurnedEvent.save()
+  let fusesSetEvent = new FusesSet(createEventID(event))  
+  fusesSetEvent.domain = node.toHex()
+  fusesSetEvent.fuses = fuses
+  fusesSetEvent.blockNumber = blockNumber
+  fusesSetEvent.transactionID = transactionID
+  fusesSetEvent.expiry = expiry
+  fusesSetEvent.save()
 }
 
 function makeWrappedTransfer(blockNumber: i32, transactionID: Bytes, eventID: string, node: BigInt, to: string): void {

--- a/src/nameWrapper.ts
+++ b/src/nameWrapper.ts
@@ -105,6 +105,7 @@ export function handleFusesSet(event: FusesSetEvent): void {
   fusesBurnedEvent.fuses = fuses
   fusesBurnedEvent.blockNumber = blockNumber
   fusesBurnedEvent.transactionID = transactionID
+  fusesBurnedEvent.expiry = expiry
   fusesBurnedEvent.save()
 }
 


### PR DESCRIPTION
the handler for `FusesSet` was missing a setter for the expiry on the event entity
- added expiry
- removed references to fusesBurned