### PR TITLE
fix: allow resolver to be set to 0x0

### DIFF
--- a/src/ensRegistry.ts
+++ b/src/ensRegistry.ts
@@ -197,7 +197,7 @@ export function handleNewResolver(event: NewResolverEvent): void {
   domainEvent.blockNumber = event.block.number.toI32();
   domainEvent.transactionID = event.transaction.hash;
   domainEvent.domain = node;
-  domainEvent.resolver = id || EMPTY_ADDRESS;
+  domainEvent.resolver = id ? id : EMPTY_ADDRESS;
   domainEvent.save();
 }
 

--- a/src/ensRegistry.ts
+++ b/src/ensRegistry.ts
@@ -161,23 +161,35 @@ export function handleTransfer(event: TransferEvent): void {
 
 // Handler for NewResolver events
 export function handleNewResolver(event: NewResolverEvent): void {
-  let id = event.params.resolver
-    .toHexString()
-    .concat("-")
-    .concat(event.params.node.toHexString());
+  let id: string | null;
+
+  // if resolver is set to 0x0, set id to null
+  // we don't want to create a resolver entity for 0x0
+  if (event.params.resolver.toHexString() === EMPTY_ADDRESS) {
+    id = null;
+  } else {
+    id = event.params.resolver
+      .toHexString()
+      .concat("-")
+      .concat(event.params.node.toHexString());
+  }
 
   let node = event.params.node.toHexString();
   let domain = getDomain(node)!;
   domain.resolver = id;
 
-  let resolver = Resolver.load(id);
-  if (resolver == null) {
-    resolver = new Resolver(id);
-    resolver.domain = event.params.node.toHexString();
-    resolver.address = event.params.resolver;
-    resolver.save();
+  if (id) {
+    let resolver = Resolver.load(id);
+    if (resolver == null) {
+      resolver = new Resolver(id);
+      resolver.domain = event.params.node.toHexString();
+      resolver.address = event.params.resolver;
+      resolver.save();
+    } else {
+      domain.resolvedAddress = resolver.addr;
+    }
   } else {
-    domain.resolvedAddress = resolver.addr;
+    domain.resolvedAddress = null;
   }
   saveDomain(domain);
 
@@ -185,7 +197,7 @@ export function handleNewResolver(event: NewResolverEvent): void {
   domainEvent.blockNumber = event.block.number.toI32();
   domainEvent.transactionID = event.transaction.hash;
   domainEvent.domain = node;
-  domainEvent.resolver = id;
+  domainEvent.resolver = id || EMPTY_ADDRESS;
   domainEvent.save();
 }
 


### PR DESCRIPTION
previously resolver entities were created for empty address resolver set events

this PR changes that behaviour to instead set the resolver on a given domain to null, and doesn't created the associated resolver entity