### PR TITLE
feat: index text changed value

### DIFF
--- a/abis/PublicResolver.json
+++ b/abis/PublicResolver.json
@@ -522,6 +522,12 @@
         "internalType": "string",
         "name": "key",
         "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "value",
+        "type": "string"
       }
     ],
     "name": "TextChanged",

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -132,6 +132,7 @@ export function handleTextChanged(event: TextChangedEvent): void {
   resolverEvent.blockNumber = event.block.number.toI32();
   resolverEvent.transactionID = event.transaction.hash;
   resolverEvent.key = event.params.key;
+  resolverEvent.value = event.params.value;
   resolverEvent.save();
 }
 

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -104,7 +104,7 @@ dataSources:
           handler: handleNameChanged
         - event: "PubkeyChanged(indexed bytes32,bytes32,bytes32)"
           handler: handlePubkeyChanged
-        - event: "TextChanged(indexed bytes32,indexed string,string)"
+        - event: "TextChanged(indexed bytes32,indexed string,string,string)"
           handler: handleTextChanged
         - event: "TextChanged(indexed bytes32,indexed string,string,string)"
           handler: handleTextChangedWithValue


### PR DESCRIPTION
Hey :wave: 
I noticed that for `textChanged` events the `value` is mostly `null` (not sure why it's there for some events where the key is `avatar`). This PR is more of the question, why the `value` isn't always indexed like this?
Any clarification would be appreciated.
Thank you!